### PR TITLE
Remove stories removes any dependant audio tracks

### DIFF
--- a/src/main/java/com/project/demo/logic/entity/story/StoryAudioTrackService.java
+++ b/src/main/java/com/project/demo/logic/entity/story/StoryAudioTrackService.java
@@ -69,4 +69,16 @@ public class StoryAudioTrackService {
             audioTrackRepository.save(femaleTrack);
         }
     }
+
+    public void deleteAudioTracksForStory(Story story) {
+        AudioTrack maleTrack = audioTrackRepository.findByStoryAndVoiceType(story, VoiceTypeEnum.MALE);
+        AudioTrack femaleTrack = audioTrackRepository.findByStoryAndVoiceType(story, VoiceTypeEnum.FEMALE);
+
+        if (maleTrack != null) {
+            audioTrackRepository.delete(maleTrack);
+        }
+        if (femaleTrack != null) {
+            audioTrackRepository.delete(femaleTrack);
+        }
+    }
 }

--- a/src/main/java/com/project/demo/rest/story/StoryRestController.java
+++ b/src/main/java/com/project/demo/rest/story/StoryRestController.java
@@ -110,6 +110,7 @@ public class StoryRestController {
     public ResponseEntity<?> deleteStory(@PathVariable Long storyId, HttpServletRequest request) {
         Optional<Story> foundStory = storyRepository.findById(storyId);
         if (foundStory.isPresent()) {
+            storyAudioTrackService.deleteAudioTracksForStory(foundStory.get());
             storyRepository.delete(foundStory.get());
             return new GlobalResponseHandler().handleResponse("Historia eliminada con éxito",
                     foundStory.get(), HttpStatus.OK, request);


### PR DESCRIPTION
## Description of the Change

<!-- Briefly explain what was modified, added, or removed in this PR -->
Removing a story works even if it has audio tracks associated. 
---

## What Was Done?

<!-- List the main actions taken in this PR -->
- Updated delete endpoint to remove stories even if they have audio tracks associated. 

---

## How to Test It

<!-- Describe the steps to verify the change works as intended -->
1. Create a new story with audio tracks. 
2. Remove the story.

---

## Related Issues

<!-- Reference any related issues or tasks using # -->
N/A

